### PR TITLE
Add Types reference

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+/// <reference types="@fastly/js-compute" />
+
 addEventListener("fetch", (event) => event.respondWith(handleRequest(event)));
 
 async function handleRequest(event) {


### PR DESCRIPTION
As we suggest in our Learning page at https://developer.fastly.com/learning/compute/javascript/#developer-experience, we should reference the Types file inside the `index.js` file.

```javascript
/// <reference types="@fastly/js-compute" />
```

This helps all IDEs that understand types, and should hurt nobody. Also, this library is already referenced in `package.json`.

This is the equivalent of https://github.com/fastly/compute-starter-kit-javascript-default/pull/22, which has already been accepted.