### PR TITLE
Adding service version logging

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -1,5 +1,12 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["<oss@fastly.com>"]
+description = "An empty application template for the Fastly Compute@Edge environment which simply returns a 200 OK response."
+language = "javascript"
 manifest_version = 2
 name = "Empty starter for JavaScript"
-description = "An empty application template for the Fastly Compute@Edge environment which simply returns a 200 OK response."
-authors = ["<oss@fastly.com>"]
-language = "javascript"
+service_id = ""
+
+[scripts]
+  build = "npm exec webpack && npm exec js-compute-runtime ./bin/index.js ./bin/main.wasm"

--- a/src/index.js
+++ b/src/index.js
@@ -3,5 +3,8 @@
 addEventListener("fetch", (event) => event.respondWith(handleRequest(event)));
 
 async function handleRequest(event) {
+  // Log service version
+  console.log("FASTLY_SERVICE_VERSION:", fastly.env.get('FASTLY_SERVICE_VERSION' || ''));
+  
   return new Response("OK", { status: 200 });
 }


### PR DESCRIPTION
Part of the quest to add version logging to every starter kit. Prints the service version to the console after running `fastly log-tail`. ([JIRA ticket](https://fastly.atlassian.net/browse/DEVLIB-856?atlOrigin=eyJpIjoiOWMyM2JjMDU1YjRjNGM1YTg5NjQzMzdhYzM1NTEyYjkiLCJwIjoiaiJ9))