### PR TITLE
js-compute => 3.1.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5,11 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "compute-starter-kit-javascript-empty",
-      "version": "0.4.0",
-      "license": "MIT",
       "dependencies": {
-        "@fastly/js-compute": "^3.0.0"
+        "@fastly/js-compute": "^3.1.0"
       }
     },
     "node_modules/@babel/regjsgen": {
@@ -479,9 +476,9 @@
       }
     },
     "node_modules/@fastly/js-compute": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-3.0.0.tgz",
-      "integrity": "sha512-ydfmUTf0Nln8Tggcwf97Hk7IYHprNr2CHZ8gPRXyVhWCKKC3iVCj6tPrSlT+4W5cVD3R4WiGQg/R0RTFAevxHA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-3.1.1.tgz",
+      "integrity": "sha512-kusHCHCCazdaTn2Ff5WxnGUrSoO2Vkmxoq0DVzqnMBE8eymfe6+fGLX+WoiaaXEqjnjH+zbzrjQSWA2ogoxGQw==",
       "dependencies": {
         "@bytecodealliance/jco": "^0.9.1",
         "@bytecodealliance/wizer": "^3.0.1",
@@ -1402,9 +1399,9 @@
       "optional": true
     },
     "@fastly/js-compute": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-3.0.0.tgz",
-      "integrity": "sha512-ydfmUTf0Nln8Tggcwf97Hk7IYHprNr2CHZ8gPRXyVhWCKKC3iVCj6tPrSlT+4W5cVD3R4WiGQg/R0RTFAevxHA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-3.1.1.tgz",
+      "integrity": "sha512-kusHCHCCazdaTn2Ff5WxnGUrSoO2Vkmxoq0DVzqnMBE8eymfe6+fGLX+WoiaaXEqjnjH+zbzrjQSWA2ogoxGQw==",
       "requires": {
         "@bytecodealliance/jco": "^0.9.1",
         "@bytecodealliance/wizer": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,7 @@
 {
-  "name": "compute-starter-kit-javascript-empty",
-  "version": "0.4.0",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/fastly/compute-starter-kit-javascript-empty.git"
-  },
   "type": "module",
-  "author": "oss@fastly.com",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/fastly/compute-starter-kit-javascript-empty/issues"
-  },
-  "homepage": "https://developer.fastly.com/solutions/starters/compute-starter-kit-javascript-empty",
   "dependencies": {
-    "@fastly/js-compute": "^3.0.0"
+    "@fastly/js-compute": "^3.1.0"
   },
   "scripts": {
     "build": "js-compute-runtime ./src/index.js ./bin/main.wasm",


### PR DESCRIPTION
Update JS SDK to 3.1.0.  Also remove a bunch of unnecessary package.json metadata which could be confusing:

- version: for some reason set to 0.4.0, possibly because that was the SDK version at the time.  we don't update it when SDKs update and we don't publish starter kits to npm so it shouldn't really be here.
- bugs: starter kit repos have github issues disabled.
- name, respository, author, license, homepage: these are all npm metadata which are unnecessary if we aren't going to publish the package, and they will be wrong the moment the customer inits from the starter kit.